### PR TITLE
Updating Pull Request training example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ Several examples of analysis that demonstrate different use cases
 * [security](security/): Example of (7.3+) Vulnerabilities and Security Hotspots.
 
 * [external-issues](external-issues/): Example of (7.2+) external linter issues import.
+
+* [pull-request](pull-request/): Example of (7.7+) support for GitHub pull request analysis

--- a/pull-request/README.md
+++ b/pull-request/README.md
@@ -3,19 +3,21 @@
 ## Use case
 This example demonstrates:
 - Scanning of a Pull Request
-- Decoration of Pull Request on GitHub
+- Addition of a Status Check to Pull Request on GitHub
 
 ## Usage
 
-Before running make sure tthere is no open pull request on GitHub.com for branch
+Before running, make sure there is no open pull request on GitHub.com for branch
 **pr-demo** (close if there is) and the following properties are set on your
 SonarQube instance:
 
-| Property                              | Value                   |
-| --------------------------------------|-------------------------|
-| sonar.pullrequest.provider            | GitHub                  |
-| sonar.pullrequest.github.endpoint     | https://api.github.com/ |
-| sonar.pullrequest.github.token.secured| YOUR_GITHUB_AUTH_TOKEN  |
+| Property                                | Value                         |
+| ----------------------------------------|-------------------------------|
+| sonar.pullrequest.provider              | GitHub                        |
+| sonar.pullrequest.github.endpoint       | https://api.github.com/       |
+| sonar.alm.github.app.name               | sonarsource-training-examples |
+| sonar.alm.github.app.id                 | 28687                         |
+| sonar.alm.github.app.privateKey.secured | Retrieve value from https://drive.google.com/file/d/17g5in0_BiL6zwiOYQCBnG3vCDFGJHaKX/view?usp=sharing    |
 
 1. Run `./setup.sh`
 
@@ -26,7 +28,9 @@ This will:
 
 2.  Create a PR on GitHub.com existing branch **pr-demo** to **master** .  Note the PR key
 
-1. Run `./scan-pr.sh PR_KEY`
+3. Run `./scan-pr.sh PR_KEY`
+
+This will:
 - Checkout the pr-demo branch from GitHub
 - Run a PR analysis on the pr-demo branch
-- Trigger PR decoration on GitHub
+- Set Status Check on PR on GitHub


### PR DESCRIPTION
I have updated the pull request training example so that it can function with SQ 7.7, which now involves using a GitHub Application to allow adding checks to pull requests.

I updated the example README file to cover the changed properties in SQ 7.7. 

NOTE: 

1. Since the Application that covers access to this example repo must now be managed as a shared resource, I have created it, gotten it installed (by Alex O.) to cover the repo, and shared the key with the team in a subdirectory of our google drive. It's linked from the README so you don't have to remember where to find it.
2. I found that the branch "pr-demo" referenced by the example did not exist, so I created one with contents that will trigger a failed quality gate check using the default javascript quality profile. I believe the original intent of the example was to keep this branch open and just create a fresh PR to represent it each time the example is performed.

I also updated the top-level README to reference the pull-request example, which it previously did not.