### PR TITLE
Correcting portfolio readme

### DIFF
--- a/portfolios/README.md
+++ b/portfolios/README.md
@@ -11,6 +11,8 @@ This will create, from the description provided in file **portfolios-def.txt**,:
    - A meaningful hierarchy of portfolios 
    - An application that recombines the 3 tiers of a web application
 
-- Re-run `./scanAllProjects.sh` to compute the portfolios
+- To compute the portfolios
+   - For SonarQube 6.x: run `sonar-scanner views`
+   - For SonarQube 7.x:, re-run `./scanAllProjects.sh`
 
 If needed you can also use the `delete-portfolios.sh` script that will remove all portfolios and applications created by the `create-portfolios.sh` script 

--- a/portfolios/README.md
+++ b/portfolios/README.md
@@ -11,6 +11,6 @@ This will create, from the description provided in file **portfolios-def.txt**,:
    - A meaningful hierarchy of portfolios 
    - An application that recombines the 3 tiers of a web application
 
-- Run `sonar-scanner views` to compute the portfolios
+- Re-run `./scanAllProjects.sh` to compute the portfolios
 
 If needed you can also use the `delete-portfolios.sh` script that will remove all portfolios and applications created by the `create-portfolios.sh` script 


### PR DESCRIPTION
I updated the "portfolios" project README file so that it no longer instructs the user to run the obsolete `sonar-scanner views` command in favor of re-running the individual project scans which would now be the recommended way to compute the portfolios.

I could have just merged this but figured I'd submit as a PR for visibility to the team.