### PR TITLE
JaCoCo coverage report in XML format

### DIFF
--- a/coverage-metrics/README.md
+++ b/coverage-metrics/README.md
@@ -13,11 +13,14 @@ The test file contains one UT without any assert statement which is bad practice
 - Run `build.sh 2 [<optional_analysis_properties>]` to build and analyze the project with one unit test (UT2) that will give another partial coverage
 - Run `build.sh all [<optional_analysis_properties>]` to build and analyze the project with both UT (UT1 and UT2) that will yield 100% coverage
 
-The `build.sh` script uses different tests files depeding on the parameter (1, 2 or both)
+The `build.sh` script uses different tests files depending on the parameter (1, 2 or both)
 and then runs:
 ```
-mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install -P coverage-per-test sonar:sonar [<optional_analysis_properties>]
+mvn clean install -P coverage sonar:sonar [<optional_analysis_properties>]
 ```
 
 ## Result
 Each different build command will create a project named "Training: Coverage Metrics X" where you can witness the resulting size metrics and coverage information
+
+## Note
+Deprecated since 5.12, JaCoCo's binary report format has been dropped with SonarJava analyser 6.0+, and this coverage training has thus been adapted for the newest XML reporting format. Find details with [this community post]

--- a/coverage-metrics/build.sh
+++ b/coverage-metrics/build.sh
@@ -19,10 +19,9 @@ elif [ "$1" = "1" ] || [ "$1" = "2" ] || [ "$1" = "all" ]; then
 	cp $testFile.ut$ut $testFile
 fi
 
-mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install \
-   -Dmaven.test.failure.ignore=true \
-   sonar:sonar -Dsonar.host.url=$SQ_URL -Dsonar.login=$SQ_TOKEN \
-   -Dsonar.exclusions=pom.xml \
-   -Dsonar.projectKey="training:test-ut$ut" -Dsonar.projectName="Training: Coverage UT $ut" $*
+mvn clean install -P coverage sonar:sonar  \
+    -Dsonar.projectKey="training:test-ut$ut"  \
+    -Dsonar.projectName="Training: Coverage UT $ut"  \
+    -Dsonar.host.url=$SQ_URL -Dsonar.login=$SQ_TOKEN
 
 exit $?

--- a/coverage-metrics/pom.xml
+++ b/coverage-metrics/pom.xml
@@ -30,8 +30,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
     </plugins>
@@ -41,36 +41,32 @@
   <!-- BEGIN: Specific to mapping unit tests and covered code -->
   <profiles>
     <profile>
-      <id>coverage-per-test</id>
+      <id>coverage</id>
       <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <!-- Minimal supported version is 2.4 -->
-            <version>2.13</version>
-            <configuration>
-              <properties>
-                <property>
-                  <name>listener</name>
-                  <value>org.sonar.java.jacoco.JUnitListener</value>
-                </property>
-              </properties>
-            </configuration>
-          </plugin>
-        </plugins>
+       <plugins>
+        <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <!-- simply use the last version -->
+        <!--version>0.8.4</version-->
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+             <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <goals>
+             <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+        </plugin>
+       </plugins>
       </build>
-
-      <dependencies>
-        <dependency>
-          <groupId>org.sonarsource.java</groupId>
-          <artifactId>sonar-jacoco-listeners</artifactId>
-          <version>3.8</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
     </profile>
-  </profiles>
-  <!-- END: Specific to mapping unit tests and covered code -->
-  
+  </profiles> 
+  <!-- END: Specific to mapping unit tests and covered code -->  
 </project>


### PR DESCRIPTION
Fix this coverage training which did not work after SonarJava 6.0+ plugin upgrade, and end of support for JaCoCo binary reporting format
Community document available at https://community.sonarsource.com/t/coverage-test-data-importing-jacoco-coverage-report-in-xml-format/12151

I also used the opportunity to make the maven file structure more standard.