### PR TITLE
Move lcov path to typescript properties

### DIFF
--- a/angular/sonar-project.properties
+++ b/angular/sonar-project.properties
@@ -8,4 +8,4 @@ sonar.exclusions=**/*.spec.ts,**/*test.ts,**/*.js
 sonar.test.inclusions=**/*.spec.ts,**/*test.ts
 sonar.coverage.exclusions=**/*.js,src/main.ts,src/polyfills.ts,**/*environment*.ts,**/*module.ts
 
-sonar.javascript.lcov.reportPaths=./coverage/angular-example/lcov.info
+sonar.typescript.lcov.reportPaths=./coverage/angular-example/lcov.info


### PR DESCRIPTION
According to the readme and other examples the lcov reportPath should be configured for typescript, not javascript.